### PR TITLE
Update English links

### DIFF
--- a/index.en.html
+++ b/index.en.html
@@ -18,7 +18,7 @@
 
     <main>
         <h2>About rgroot</h2>
-        rgroot is one of the research/study groups in the <a href="https://rg.sfc.keio.ac.jp/">Tokuda/Murai Joint Research Project</a> at Keio University Shonan Fujisawa Campus.  Our research activities consist of both research on information and communication technology and actual network operation, including laboratory network operation, paper lectures on network technology, and promotion of individual research.  Our group is responsible for managing the network used by the joint research project as a whole.
+        rgroot is one of the research/study groups in the <a href="https://rg.sfc.keio.ac.jp/index.en.html">Tokuda/Murai Joint Research Project</a> at Keio University Shonan Fujisawa Campus.  Our research activities consist of both research on information and communication technology and actual network operation, including laboratory network operation, paper lectures on network technology, and promotion of individual research.  Our group is responsible for managing the network used by the joint research project as a whole.
         
         <h2>Research topics</h2>
         Our main research topics include the following, but students are not limited to only these.  Members are free to choose and tackle a topic of their choice.
@@ -59,10 +59,10 @@
 
         <h2>Related links</h2>
         <ul>
-            <li><a href="https://www.sfc.keio.ac.jp/">Keio University Shonan Fujisawa Campus</a></li>
-            <li><a href="https://rg.sfc.keio.ac.jp/" target="_blank">Tokuda/Murai/Kusumoto/Nakamura/Van Meter/Uehara/Mitsugi/Nakazawa/Takeda Joint Research Project</a></li>
+            <li><a href="https://www.sfc.keio.ac.jp/en/">Keio University Shonan Fujisawa Campus</a></li>
+            <li><a href="https://rg.sfc.keio.ac.jp/index.en.html" target="_blank">Tokuda/Murai/Kusumoto/Nakamura/Van Meter/Uehara/Mitsugi/Nakazawa/Takeda Joint Research Project</a></li>
             <li><a href="https://www.sfc.wide.ad.jp/">Internet Research Lab (Jun Murai Laboratory)</a></li>
-            <li><a href="http://www.wide.ad.jp/" target="_blank">WIDE Project</a></li>
+            <li><a href="http://www.wide.ad.jp/index_e.html" target="_blank">WIDE Project</a></li>
         </ul>
     </main>
 


### PR DESCRIPTION
Link to English home page instead of (Japanese) site home page
(#7 マージした後気づいてしまった)